### PR TITLE
Remove yarn cache to avoid actions/cache bug

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,18 +10,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: "12.x"
-      - name: Get yarn cache directory path
-        id: cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v1
-        id: cache
-        with:
-          path: ${{ steps.cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
       - run: yarn install
-        if: steps.cache.outputs.cache-hit != 'true'
       - run: yarn test
       - run: yarn format-check
       - run: yarn lint


### PR DESCRIPTION
Currently, [actions/cache](https://github.com/actions/cache) has a bug that misses some dependencies. In this case, the restored cache is always missing jest.

This PR removes cache processing in the workflow as a workaround.

ref) https://github.com/actions/cache/issues/281